### PR TITLE
Add `aliases: true` in YAML.load

### DIFF
--- a/lib/cloner/ar.rb
+++ b/lib/cloner/ar.rb
@@ -1,7 +1,7 @@
 module Cloner::Ar
   def read_ar_conf
     @conf ||= begin
-      YAML.load(ERB.new(File.read(Rails.root.join('config', 'database.yml'))).result)[env_database]
+      YAML.load(ERB.new(File.read(Rails.root.join('config', 'database.yml'))).result, aliases: true)[env_database]
     end
   end
   def ar_conf
@@ -35,7 +35,7 @@ module Cloner::Ar
         ret = ssh_exec!(ssh, "cat #{e(remote_app_path + '/config/database.yml')}")
         check_ssh_err(ret)
         begin
-          res = YAML.load(ERB.new(ret[0]).result)[env_from]
+          res = YAML.load(ERB.new(ret[0]).result, aliases: true)[env_from]
           raise 'no data' if res.blank?
           #res['host'] ||= '127.0.0.1'
         rescue Exception => e


### PR DESCRIPTION
Fix error:
```
~/.rvm/gems/ruby-3.0.4/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:432:in `visit_Psych_Nodes_Alias': 
Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`. (Psych::AliasesNotEnabled)
```